### PR TITLE
Add Xquik and repair Post Exploitation navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Welcome to the **Cybersources**! This project serves as a central hub for a wide
     * [Tinder](#177--tinder)
     * [Reddit](#178--reddit)
     * [Telegram](#179--telegram)
+    * [X/Twitter](#1710--xtwitter)
 
 **Pentesting**
 * [Post Explotation](#21--post-explotation)
@@ -503,6 +504,12 @@ Welcome to the **Cybersources**! This project serves as a central hub for a wide
 | Tools                                              | Description                                                    |
 | -------------------------------------------------- | -------------------------------------------------------------- |
 | [telegram-checker](https://github.com/unnohwn/telegram-checker) | A Python tool for checking Telegram accounts via phone numbers or usernames. Automatically verifies account existence, downloads profile pictures, and provides detailed user information in a clean JSON format. Built with Telethon API for reliable Telegram interaction. |
+
+#### 1.7.10 [↑](#-content) X/Twitter
+
+| Tools                                              | Description                                                    |
+| -------------------------------------------------- | -------------------------------------------------------------- |
+| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter data API for tweet search, profile lookups, follower exports, media downloads, monitoring, and webhooks. |
 
 ## 2. [↑](#-content) Pentesting
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Welcome to the **Cybersources**! This project serves as a central hub for a wide
     * [X/Twitter](#1710--xtwitter)
 
 **Pentesting**
-* [Post Explotation](#21--post-explotation)
+* [Post Exploitation](#21--post-exploitation)
 * [Deobfuscators](#22--deobfuscators) 
 * [Decompilers](#23--decompilers) 
 * [Disassembler and debuggers](#24--Disassembler-and-debuggers)
@@ -509,11 +509,13 @@ Welcome to the **Cybersources**! This project serves as a central hub for a wide
 
 | Tools                                              | Description                                                    |
 | -------------------------------------------------- | -------------------------------------------------------------- |
-| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter data API for tweet search, profile lookups, follower exports, media downloads, monitoring, and webhooks. |
+| [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) | X/Twitter data platform with 40+ tools, REST, webhooks, and MCP for search, profile research, follower exports, media downloads, and monitoring. |
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ## 2. [↑](#-content) Pentesting
 
-### 2.1 [↑](#-content) Post Explotation
+### 2.1 [↑](#-content) Post Exploitation
 
 | Tools                                                         | Description                                                                         |
 | ------------------------------------------------------------- | ----------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Add Xquik to the X/Twitter OSINT section.
- Describe its current 40+ tools, REST, webhooks, and MCP capabilities.
- Add the required independent-service and trademark disclosure.
- Fix the repository's misspelled Post Exploitation navigation and heading.

## Independent repository fix

The Post Exploitation label was misspelled in both the table of contents and its section heading. This repair updates both together, preserving a working internal link while improving the catalogue independently of Xquik.

## Validation

- `git diff --check`
- Verified the Xquik repository and website return HTTP 200.
- Verified the Post Exploitation navigation target matches its heading.
- Verified exactly 1 Xquik listing and 1 required disclosure.
- Verified no prohibited dash character appears in changed lines.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
