### PR TITLE
Add Nutilz Hash Generator to Cracking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1411,6 +1411,7 @@ Xquik is an independent third-party service. Not affiliated with X Corp. "Twitte
 |--------------------------------------------|---------------------------------------------------------------------------------|
 | [CrackStation](https://crackstation.net/)  | A tool for cracking hashes and testing password strength.                       |
 | [MD5 Hash Generator](https://www.md5hashgenerator.com/) | A tool to generate MD5 hashes from input data.                                  |
+| [Nutilz Hash Generator](https://nutilz.com/hash-generator) | Free browser-based tool to generate SHA-1, SHA-256, SHA-384 and SHA-512 hashes from text — 100% client-side, no data leaves your device. |
 | [Kaspersky Password Checker](https://password.kaspersky.com/es/) | A service to check the strength of your passwords.                              |
 | [1Password (Developers and Students)](https://1password.com/developers/students) | A secure password manager offering discounts for developers and students.       |
 | [ZIP Password Cracker](https://github.com/ivanbg2004/zip-password-cracker) |Script to crack password-protected ZIP files using brute force. BY OD&H.|


### PR DESCRIPTION
Adds a free browser-based hash generator (SHA-1/256/384/512) to the 8.4 Cracking section, alongside the existing MD5 Hash Generator entry. It runs entirely client-side via the Web Crypto API — no upload, no server round-trip. Live at https://nutilz.com/hash-generator.