### PR TITLE
Add CC.LA — free OSINT domain & network toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Welcome to the **Cybersources**! This project serves as a central hub for a wide
 | [LensoAI](https://lenso.ai/en)                                                                                                                         | AI-driven platform for reverse image searching.                                                 |
 | [OSINT Investigation Assistant](https://lambda.black/osint.html)| An OSINT Investigation Assistant designed to help with people investigations |
 | [ClatScope](https://github.com/Clats97/ClatScope)|The best and most versatile OSINT utility for retrieving geolocation, DNS, WHOIS, phone, email, data breach information and much more (42 features).|
+| [CC.LA](https://cc.la) | Free online toolkit for WHOIS, RDAP, DNS, IP WHOIS, SSL certificate lookup, name server history, network diagnostics, and domain monitoring. No sign-up. |
 | [DataSurgeon](https://github.com/Drew-Alleman/DataSurgeon)|It allows for the extraction of various types of sensitive information including emails, phone numbers, hashes, credit cards, URLs, IP addresses, MAC addresses, SRV DNS records and more.|
 |[Deep Dork Web](https://guilherme-moraiss.github.io/Deep-Dork-Web/)|Automate Google Dorking for OSINT investigations. Search indexed sensitive data efficiently with pre-built queries.|
 |[Digital Digging OSINT](https://digitaldigging.org/osint/)|Collection of OSINT resources are organized by country and are useful for researchers, fact-checkers, and digital profilers.|


### PR DESCRIPTION
Add [CC.LA](https://cc.la) to OSINT section — a free online toolkit for WHOIS, RDAP, DNS, IP WHOIS, SSL certificate lookup, name server history, network diagnostics (ping/traceroute/MTR), and domain monitoring. No sign-up required.