### PR TITLE
Add CT Log Finder to Cryptography section

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ Xquik is an independent third-party service. Not affiliated with X Corp. "Twitte
 | [Cyberchef](https://gchq.github.io/CyberChef)    | A powerful web-based tool for encoding, decoding, encryption, and data analysis        | 
 | [Don´t Leak My File](https://github.com/JkDevArg/dont-leak-my-file) | Document leak protection application developed in Python. It uses AES-256 encrypted watermarks and database tracking to detect potential leaks.|
 | [SkyCrypt](https://github.com/JkDevArg/skycript) | SkyCrypt is a file encryption and decryption application developed in Python. It uses the AES-256 algorithm to securely encrypt files and generates a one-time password (OTP) to validate decryption.  |
+| [CT Log Finder](https://nutilz.com/ct-log-finder) | Free tool that searches Certificate Transparency logs to discover subdomains issued TLS certificates for a given domain — useful for recon and attack surface mapping. |
 
 ### [↑](#-content) 3.2 Steganographic
 


### PR DESCRIPTION
Adds [CT Log Finder](https://nutilz.com/ct-log-finder), a free tool that queries Certificate Transparency logs to discover subdomains that have had TLS certificates issued for a given domain. Useful for recon / attack surface mapping. No signup required, free to use.