### PR TITLE
Add Authier password manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,6 +1094,7 @@ Xquik is an independent third-party service. Not affiliated with X Corp. "Twitte
 | [Bitwarden](https://bitwarden.com/)                    | Freemium | A password manager that securely stores manages and syncs credentials across any browsers or devices. |
 | [LastPass](https://www.lastpass.com/es) | Free | Simplify your digital life with a password manager that automatically creates, saves, and fills strong passwords. |
 | [Proton Pass](https://proton.me/pass) | Freemium | An open-source, encrypted password manager that includes built-in 2FA and email masking (hide-my-email aliases) to protect user privacy. |
+| [Authier](https://www.authier.pm/) | Freemium | An early-stage AGPL-3.0-or-later password manager for credentials and TOTP codes, with browser extensions, a web vault, client-side encrypted sync, and trusted-device approval; not independently audited. |
 
 ### [↑](#-content) 5.3 VPNs
 


### PR DESCRIPTION
## Summary

- Add Authier to the Password Managers table.
- Describe its current public scope: credentials and TOTP codes, browser extensions, a web vault, client-side encrypted sync, and trusted-device approval.
- Keep the early-stage and no-independent-audit limitations explicit in the catalogue row.

## Verification

- `git diff --check`
- Confirmed the change is exactly one README row in the existing three-column table.
- Confirmed the canonical homepage, https://www.authier.pm/, returns HTTP 200.
- Confirmed the repository license is GNU AGPL v3; the project applies the license as AGPL-3.0-or-later.

This repository has no automated test or build configuration, so validation is limited to the Markdown diff, table shape, factual source review, and live target link.

## Disclosure

I maintain Authier and am proposing my own project for inclusion. OpenAI Codex helped research the catalogue fit, verify the public claims and deployment behavior, and prepare this one-line contribution and pull-request text. I reviewed the change and take responsibility for its contents.

Authier is early-stage and has not undergone an independent security audit.